### PR TITLE
feat(sdlc): release 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": "dist/bin.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "description": "typescript project meta analysis",
   "engines": {
     "node": "22.x.x"


### PR DESCRIPTION
Background: semantic-release-bot doesn't support v0 as major version (https://github.com/semantic-release/semantic-release/issues/1507#issuecomment-1586336762), so without further tweaking attempts, let's just mark our current working version as 1.0.0 and be done with it.